### PR TITLE
feat: OpenAI-compatible API provider (alternative to local GGUF)

### DIFF
--- a/KeyType.xcodeproj/project.pbxproj
+++ b/KeyType.xcodeproj/project.pbxproj
@@ -65,6 +65,9 @@
 		4B5450012FC9600000000211 /* UpdaterController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5450012FC9600000000210 /* UpdaterController.swift */; };
 		4B5450012FC96000000002A1 /* CompletionPromotionCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5450012FC96000000002A0 /* CompletionPromotionCache.swift */; };
 		4B5450012FC96000000002A3 /* CompletionReuseHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5450012FC96000000002A2 /* CompletionReuseHistory.swift */; };
+		75F3D0E14FE25E72A70ABE6F /* CompletionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7DF99FA6A1590F9F6DCCCC /* CompletionEngine.swift */; };
+		C4DB432C358A5C10A94F913C /* ConstrainedGenerationEngine+CompletionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B96271C1F67E55DE85643EDC /* ConstrainedGenerationEngine+CompletionEngine.swift */; };
+		0827BB0DCC8150A7B3067375 /* OpenAICompletionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1C058846F956E48C29306C /* OpenAICompletionEngine.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -133,6 +136,9 @@
 		4B5450012FC9600000000220 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4B5450012FC96000000002A0 /* CompletionPromotionCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionPromotionCache.swift; sourceTree = "<group>"; };
 		4B5450012FC96000000002A2 /* CompletionReuseHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionReuseHistory.swift; sourceTree = "<group>"; };
+		2A7DF99FA6A1590F9F6DCCCC /* CompletionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionEngine.swift; sourceTree = "<group>"; };
+		B96271C1F67E55DE85643EDC /* ConstrainedGenerationEngine+CompletionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstrainedGenerationEngine+CompletionEngine.swift; sourceTree = "<group>"; };
+		6A1C058846F956E48C29306C /* OpenAICompletionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAICompletionEngine.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -276,6 +282,9 @@
 		4B5450012FC9600000000100 /* Completion */ = {
 			isa = PBXGroup;
 			children = (
+				6A1C058846F956E48C29306C /* OpenAICompletionEngine.swift */,
+				B96271C1F67E55DE85643EDC /* ConstrainedGenerationEngine+CompletionEngine.swift */,
+				2A7DF99FA6A1590F9F6DCCCC /* CompletionEngine.swift */,
 				4B5450012FC9600000000080 /* AcceptanceShortcut.swift */,
 				4B5450012FC9600000000042 /* CompletionAcceptanceController.swift */,
 				4B5450012FC9600000000040 /* CompletionController.swift */,
@@ -593,6 +602,9 @@
 				4B5450012FC96000000000C9 /* PermissionOverlayWindowController.swift in Sources */,
 				4B5450012FC96000000000CB /* PermissionGuidanceController.swift in Sources */,
 				4B5450012FC96000000000CD /* ScreenFrameReader.swift in Sources */,
+				75F3D0E14FE25E72A70ABE6F /* CompletionEngine.swift in Sources */,
+				C4DB432C358A5C10A94F913C /* ConstrainedGenerationEngine+CompletionEngine.swift in Sources */,
+				0827BB0DCC8150A7B3067375 /* OpenAICompletionEngine.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/KeyType/Logic/Completion/CompletionController.swift
+++ b/KeyType/Logic/Completion/CompletionController.swift
@@ -55,7 +55,7 @@ final class CompletionController {
     private let predictionLog = PredictionLog()
     private let log = Logger(subsystem: "com.pattonium.KeyType", category: "completion")
 
-    private var engine: ConstrainedGenerationEngine?
+    private var engine: (any CompletionEngine)?
     private var generationTask: Task<Void, Never>?
     private var debounceTask: Task<Void, Never>?
     private var warmupTask: Task<Void, Never>?
@@ -194,13 +194,16 @@ final class CompletionController {
         let adjustments = ThresholdTuner.adjustments(for: telemetry.snapshot())
         let modelFilename = settings.selectedModelFilename ?? ModelContainer.defaultModelFilename
         activeModelFilename = modelFilename
+        let useRemote = settings.useRemoteModel
         Task {
             do {
-                let engine = try await Self.buildEngine(
-                    compatibilityStore: compatibilityStore,
-                    modelFilename: modelFilename,
-                    adjustments: adjustments
-                )
+                let engine = useRemote
+                    ? try await Self.buildRemoteEngine(settings: settings)
+                    : try await Self.buildEngine(
+                        compatibilityStore: compatibilityStore,
+                        modelFilename: modelFilename,
+                        adjustments: adjustments
+                    )
                 self.engine = engine
                 self.loadState = .ready
                 self.startStartupWarmup(engine: engine)
@@ -219,7 +222,7 @@ final class CompletionController {
     /// concurrent engine builds.
     func reloadModel() {
         let target = settings.selectedModelFilename ?? ModelContainer.defaultModelFilename
-        guard target != activeModelFilename || loadState == .idle else { return }
+        guard target != activeModelFilename || loadState == .idle || settings.useRemoteModel else { return }
         activeModelFilename = target
         reset()
         lastGenerationLatencyMs = nil
@@ -588,7 +591,7 @@ final class CompletionController {
         ].joined(separator: "\u{1E}")
     }
 
-    private func startStartupWarmup(engine: ConstrainedGenerationEngine) {
+    private func startStartupWarmup(engine: some CompletionEngine) {
         warmupTask?.cancel()
         let context = TextFieldContext(
             beforeCursor: "The",
@@ -606,11 +609,11 @@ final class CompletionController {
         startWarmup(engine: engine, request: request)
     }
 
-    private func startAnchorWarmup(engine: ConstrainedGenerationEngine, request: CompletionRequest) {
+    private func startAnchorWarmup(engine: some CompletionEngine, request: CompletionRequest) {
         startWarmup(engine: engine, request: request)
     }
 
-    private func startWarmup(engine: ConstrainedGenerationEngine, request: CompletionRequest) {
+    private func startWarmup(engine: some CompletionEngine, request: CompletionRequest) {
         warmupTask?.cancel()
         warmupTask = Task { [weak self] in
             do {
@@ -1122,13 +1125,25 @@ final class CompletionController {
         )
     }
 
+    /// Builds a remote (OpenAI-compatible API) completion engine. Runs off the main actor.
+    /// Throws when no API model is configured or selected.
+    nonisolated private static func buildRemoteEngine(settings: SettingsStore) async throws -> any CompletionEngine {
+        guard let config = settings.activeAPIModel else {
+            throw CompletionLoadError.noAPIModelConfigured
+        }
+        return OpenAICompletionEngine(config: config)
+    }
+
     enum CompletionLoadError: Error, CustomStringConvertible {
         case modelMissing(String)
+        case noAPIModelConfigured
 
         var description: String {
             switch self {
             case let .modelMissing(name):
                 return "Model file '\(name)' not found in Application Support/KeyType/Models"
+            case .noAPIModelConfigured:
+                return "No API model configured. Add one in Settings → Model → API Models."
             }
         }
     }

--- a/KeyType/Logic/Completion/CompletionEngine.swift
+++ b/KeyType/Logic/Completion/CompletionEngine.swift
@@ -1,0 +1,29 @@
+//
+//  CompletionEngine.swift
+//  KeyType
+//
+//  Protocol abstracting over local (llama.cpp) and remote (OpenAI-compatible API) completion
+//  engines so CompletionController can use either without coupling to the concrete type.
+//
+
+import AutocompleteCore
+import Foundation
+
+/// Interface every completion engine must implement: generating completions, warming up, and
+/// releasing resources. Both the local `ConstrainedGenerationEngine` and the new
+/// `OpenAICompletionEngine` conform to this protocol.
+public protocol CompletionEngine {
+    /// Generate completion candidates for the given request. Throw on transient errors; return an
+    /// empty array when the engine cannot produce a sensible completion (e.g. the user is typing in
+    /// a field whose app policy suppresses completions).
+    func completions(for request: CompletionRequest) async throws -> [CompletionCandidate]
+
+    /// Optional warm-up: run a cheap forward pass so the first real generation is faster. The local
+    /// engine uses this to prime the GPU; remote engines may skip or use a lightweight connectivity
+    /// check. Safe to call redundantly.
+    func warmUp(for request: CompletionRequest) async throws
+
+    /// Release any native resources (model handles, GPU memory, network connections). Called during
+    /// engine reload and app shutdown.
+    func shutdown() async
+}

--- a/KeyType/Logic/Completion/ConstrainedGenerationEngine+CompletionEngine.swift
+++ b/KeyType/Logic/Completion/ConstrainedGenerationEngine+CompletionEngine.swift
@@ -1,0 +1,10 @@
+//
+//  ConstrainedGenerationEngine+CompletionEngine.swift
+//  KeyType
+//
+//  Conformance of the local constrained decoder to the shared CompletionEngine protocol.
+//
+
+import ConstrainedGeneration
+
+extension ConstrainedGenerationEngine: CompletionEngine {}

--- a/KeyType/Logic/Completion/OpenAICompletionEngine.swift
+++ b/KeyType/Logic/Completion/OpenAICompletionEngine.swift
@@ -1,0 +1,184 @@
+//
+//  OpenAICompletionEngine.swift
+//  KeyType
+//
+//  A CompletionEngine that routes prompts to any OpenAI-compatible chat endpoint (LM Studio,
+//  Ollama, vLLM, cloud APIs) instead of running a local GGUF model. This saves Mac GPU/RAM
+//  resources by offloading inference to an external server.
+//
+
+import AutocompleteCore
+import Foundation
+
+/// Configuration for an OpenAI-compatible API endpoint.
+struct APIModelConfig: Codable, Equatable, Identifiable {
+    var id: UUID
+    /// User-visible label (e.g. "LM Studio - Qwen 2.5").
+    var displayName: String
+    /// Base URL of the API (e.g. "http://localhost:1234/v1").
+    var endpoint: String
+    /// API key, or empty for local servers that don't require one.
+    var apiKey: String
+    /// Model name sent in the request body (e.g. "qwen2.5-7b-instruct").
+    var modelName: String
+
+    init(
+        id: UUID = UUID(),
+        displayName: String,
+        endpoint: String,
+        apiKey: String = "",
+        modelName: String
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.endpoint = endpoint
+        self.apiKey = apiKey
+        self.modelName = modelName
+    }
+}
+
+/// Completion engine that sends prompts to an OpenAI-compatible chat API.
+///
+/// Converts the prompt built by KeyType into a chat message, sends it to the configured
+/// endpoint, and wraps the response text back into `CompletionCandidate`s.
+final class OpenAICompletionEngine: CompletionEngine {
+    private let config: APIModelConfig
+    private let session: URLSession
+    private let decoder = JSONDecoder()
+
+    init(config: APIModelConfig) {
+        self.config = config
+        let cfg = URLSessionConfiguration.default
+        cfg.timeoutIntervalForRequest = 30
+        cfg.timeoutIntervalForResource = 60
+        self.session = URLSession(configuration: cfg)
+    }
+
+    // MARK: - CompletionEngine
+
+    func completions(for request: CompletionRequest) async throws -> [CompletionCandidate] {
+        // Build the chat request from the prompt KeyType constructed.
+        let url = try buildURL(path: "/chat/completions")
+        let body = ChatCompletionRequest(
+            model: config.modelName,
+            messages: [.init(role: "user", content: request.prompt)],
+            maxTokens: max(1, request.maxCompletionTokens),
+            temperature: 0,
+            stream: false
+        )
+
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if !config.apiKey.isEmpty {
+            urlRequest.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+        }
+        urlRequest.httpBody = try JSONEncoder().encode(body)
+
+        let (data, response) = try await session.data(for: urlRequest)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw OpenAIError.invalidResponse
+        }
+        guard (200...299).contains(httpResponse.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? "<empty>"
+            throw OpenAIError.httpError(statusCode: httpResponse.statusCode, body: body)
+        }
+
+        let chatResponse = try decoder.decode(ChatCompletionResponse.self, from: data)
+
+        guard let choice = chatResponse.choices.first else {
+            return []
+        }
+
+        let text = choice.message.content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return [] }
+
+        return [
+            CompletionCandidate(
+                text: text,
+                logProbability: 0,   // remote APIs don't expose per-token logprobs reliably
+                displayWidth: text.count,
+                mode: request.mode
+            )
+        ]
+    }
+
+    func warmUp(for request: CompletionRequest) async throws {
+        // Lightweight connectivity check: list models or just a minimal completion.
+        // If the endpoint is unreachable the error surfaces on the first real generation.
+        _ = try await completions(for: request)
+    }
+
+    func shutdown() async {
+        session.invalidateAndCancel()
+    }
+
+    // MARK: - Helpers
+
+    private func buildURL(path: String) throws -> URL {
+        let base = config.endpoint.hasSuffix("/") ? String(config.endpoint.dropLast()) : config.endpoint
+        guard let url = URL(string: base + path) else {
+            throw OpenAIError.invalidURL(config.endpoint + path)
+        }
+        return url
+    }
+}
+
+// MARK: - OpenAI API types
+
+private struct ChatCompletionRequest: Encodable {
+    let model: String
+    let messages: [Message]
+    let maxTokens: Int
+    let temperature: Double
+    let stream: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case model, messages, temperature, stream
+        case maxTokens = "max_tokens"
+    }
+
+    struct Message: Encodable {
+        let role: String
+        let content: String
+    }
+}
+
+private struct ChatCompletionResponse: Decodable {
+    let choices: [Choice]
+
+    struct Choice: Decodable {
+        let message: Message
+        let finishReason: String?
+
+        enum CodingKeys: String, CodingKey {
+            case message
+            case finishReason = "finish_reason"
+        }
+    }
+
+    struct Message: Decodable {
+        let role: String?
+        let content: String
+    }
+}
+
+// MARK: - Errors
+
+enum OpenAIError: Error, LocalizedError {
+    case invalidURL(String)
+    case invalidResponse
+    case httpError(statusCode: Int, body: String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .invalidURL(url):
+            return "Invalid API endpoint URL: \(url)"
+        case .invalidResponse:
+            return "Invalid response from API server"
+        case let .httpError(code, body):
+            return "API returned HTTP \(code): \(body)"
+        }
+    }
+}

--- a/KeyType/Logic/Settings/SettingsStore.swift
+++ b/KeyType/Logic/Settings/SettingsStore.swift
@@ -64,6 +64,11 @@ final class SettingsStore {
         static let acceptFullKeyCode = "KeyType.settings.acceptFullKeyCode"
         static let acceptFullModifiers = "KeyType.settings.acceptFullModifiers"
         static let acceptFullLabel = "KeyType.settings.acceptFullLabel"
+
+        // API model settings
+        static let useRemoteModel = "KeyType.settings.useRemoteModel"
+        static let apiModels = "KeyType.settings.apiModels"
+        static let selectedAPIModelID = "KeyType.settings.selectedAPIModelID"
     }
 
     private let defaults: UserDefaults
@@ -97,6 +102,34 @@ final class SettingsStore {
         didSet { defaults.set(Array(perAppDisabled).sorted(), forKey: Key.perAppDisabled) }
     }
 
+    // MARK: - API (remote) model settings
+
+    /// When true, use a remote OpenAI-compatible API instead of the local GGUF model.
+    /// Requires at least one configured API model to be selected.
+    var useRemoteModel: Bool {
+        didSet { defaults.set(useRemoteModel, forKey: Key.useRemoteModel) }
+    }
+
+    /// Configured remote API endpoints.
+    var apiModels: [APIModelConfig] {
+        didSet {
+            if let data = try? JSONEncoder().encode(apiModels) {
+                defaults.set(data, forKey: Key.apiModels)
+            }
+        }
+    }
+
+    /// The ID of the currently selected API model, or nil.
+    var selectedAPIModelID: UUID? {
+        didSet { defaults.set(selectedAPIModelID?.uuidString, forKey: Key.selectedAPIModelID) }
+    }
+
+    /// Returns the currently selected API model config, or nil.
+    var activeAPIModel: APIModelConfig? {
+        guard let id = selectedAPIModelID else { return nil }
+        return apiModels.first { $0.id == id }
+    }
+
     /// Hotkey that accepts the next word of the visible suggestion. Defaults to Tab.
     var acceptWordShortcut: AcceptanceShortcut {
         didSet { persist(acceptWordShortcut, keyCode: Key.acceptWordKeyCode, modifiers: Key.acceptWordModifiers, label: Key.acceptWordLabel) }
@@ -116,6 +149,17 @@ final class SettingsStore {
             .flatMap(CompletionLength.init(rawValue:)) ?? .medium
         self.selectedModelFilename = defaults.string(forKey: Key.selectedModelFilename)
         self.perAppDisabled = Set(defaults.stringArray(forKey: Key.perAppDisabled) ?? [])
+        self.useRemoteModel = defaults.bool(forKey: Key.useRemoteModel)
+        self.apiModels = {
+            guard let data = defaults.data(forKey: Key.apiModels),
+                  let decoded = try? JSONDecoder().decode([APIModelConfig].self, from: data)
+            else { return [] }
+            return decoded
+        }()
+        self.selectedAPIModelID = {
+            guard let s = defaults.string(forKey: Key.selectedAPIModelID) else { return nil }
+            return UUID(uuidString: s)
+        }()
         self.acceptWordShortcut = Self.loadShortcut(
             defaults: defaults,
             keyCodeKey: Key.acceptWordKeyCode,

--- a/KeyType/Views/Settings/Sections/ModelSettingsView.swift
+++ b/KeyType/Views/Settings/Sections/ModelSettingsView.swift
@@ -3,7 +3,8 @@
 //  KeyType
 //
 //  The "Model" Settings pane: the active model picker, the catalog of downloadable/installed models
-//  with their live setup state, and "import your own GGUF". Split out of SettingsView so each sidebar
+//  with their live setup state, "import your own GGUF", and configuration for remote OpenAI-compatible
+//  API models as an alternative to local GGUF inference. Split out of SettingsView so each sidebar
 //  category lives in its own file. See ADR-021.
 //
 
@@ -22,66 +23,213 @@ struct ModelSettingsView: View {
     let importModel: () -> Void
 
     @State private var availableModels: [String] = []
+    @State private var showAddAPIModel = false
+    /// Ephemeral editing state for the "add API model" sheet.
+    @State private var editDisplayName = ""
+    @State private var editEndpoint = ""
+    @State private var editAPIKey = ""
+    @State private var editModelName = ""
 
     var body: some View {
         Form {
-            Section("Model") {
-                Picker("Completion model", selection: $settings.selectedModelFilename) {
-                    Text("Default (\(ModelContainer.defaultModelFilename))").tag(String?.none)
-                    ForEach(availableModels, id: \.self) { name in
-                        Text(name).tag(String?.some(name))
-                    }
+            // ── Engine type toggle ────────────────────────────────────────
+            Section {
+                Picker("Engine", selection: $settings.useRemoteModel) {
+                    Text("Local (GGUF)").tag(false)
+                    Text("Remote API").tag(true)
                 }
-                // Honor the "takes effect immediately" promise: a new selection flushes the resident
-                // model + KV cache and reloads from the chosen GGUF without a relaunch (see ADR-021).
-                .onChange(of: settings.selectedModelFilename) { reloadModel() }
+                .pickerStyle(.radioGroup)
+                .onChange(of: settings.useRemoteModel) { reloadModel() }
+            } footer: {
+                Text(settings.useRemoteModel
+                    ? "Offload inference to an external server — saves Mac GPU/RAM resources."
+                    : "Run models directly on your Mac using llama.cpp."
+                )
+                .font(.footnote)
+                .foregroundStyle(.secondary)
             }
 
-            Section("Available models") {
-                ForEach(modelSetup.catalog) { model in
-                    SettingsModelRow(
-                        model: model,
-                        state: modelSetup.state(for: model),
-                        isInstalled: modelSetup.downloads.isInstalled(filename: model.filename),
-                        onSetup: { modelSetup.beginSetup(for: model) },
-                        onCancel: { modelSetup.cancel(model) },
-                        onPause: { modelSetup.pause(model) },
-                        onResume: { modelSetup.resume(model) },
-                        onDelete: {
-                            modelSetup.downloads.deleteModel(filename: model.filename)
-                            modelSetup.refresh()
-                            availableModels = Self.loadModels()
+            if settings.useRemoteModel {
+                remoteModelSection
+            } else {
+                localModelSection
+            }
+        }
+        .formStyle(.grouped)
+        .sheet(isPresented: $showAddAPIModel) {
+            addAPIModelSheet
+        }
+        .task { availableModels = Self.loadModels() }
+        .onChange(of: modelSetupSignature) { availableModels = Self.loadModels() }
+        .onChange(of: modelSetup.importState) { availableModels = Self.loadModels() }
+    }
+
+    // MARK: - Local model section (existing)
+
+    @ViewBuilder
+    private var localModelSection: some View {
+        Section("Model") {
+            Picker("Completion model", selection: $settings.selectedModelFilename) {
+                Text("Default (\(ModelContainer.defaultModelFilename))").tag(String?.none)
+                ForEach(availableModels, id: \.self) { name in
+                    Text(name).tag(String?.some(name))
+                }
+            }
+            .onChange(of: settings.selectedModelFilename) { reloadModel() }
+        }
+
+        Section("Available models") {
+            ForEach(modelSetup.catalog) { model in
+                SettingsModelRow(
+                    model: model,
+                    state: modelSetup.state(for: model),
+                    isInstalled: modelSetup.downloads.isInstalled(filename: model.filename),
+                    onSetup: { modelSetup.beginSetup(for: model) },
+                    onCancel: { modelSetup.cancel(model) },
+                    onPause: { modelSetup.pause(model) },
+                    onResume: { modelSetup.resume(model) },
+                    onDelete: {
+                        modelSetup.downloads.deleteModel(filename: model.filename)
+                        modelSetup.refresh()
+                        availableModels = Self.loadModels()
+                    }
+                )
+            }
+        }
+
+        Section {
+            Button("Import a GGUF…", action: importModel)
+                .disabled(isImporting)
+            importStatusLine
+        } header: {
+            Text("Use your own base model")
+        } footer: {
+            Text("KeyType is tuned for the models above; other models may produce unexpected or low-quality completions.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Remote API model section
+
+    @ViewBuilder
+    private var remoteModelSection: some View {
+        if settings.apiModels.isEmpty {
+            Section {
+                Button("Add API Model…") { presentAddSheet() }
+            } footer: {
+                Text("Add an OpenAI-compatible endpoint (LM Studio, Ollama, vLLM, or any cloud API).")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        } else {
+            Section("API Models") {
+                ForEach(settings.apiModels) { model in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(model.displayName).font(.body)
+                            Text(model.endpoint)
+                                .font(.caption.monospaced())
+                                .foregroundStyle(.secondary)
+                            Text("Model: \(model.modelName)")
+                                .font(.caption)
+                                .foregroundStyle(.tertiary)
                         }
-                    )
+                        Spacer()
+                        if model.id == settings.selectedAPIModelID {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(.green)
+                        }
+                    }
+                    .padding(.vertical, 2)
+                }
+                .onDelete { indexSet in
+                    let toRemove = indexSet.map { settings.apiModels[$0].id }
+                    settings.apiModels.remove(atOffsets: indexSet)
+                    if settings.selectedAPIModelID.map({ toRemove.contains($0) }) == true {
+                        settings.selectedAPIModelID = settings.apiModels.first?.id
+                        reloadModel()
+                    }
                 }
             }
 
             Section {
-                Button("Import a GGUF…", action: importModel)
-                    .disabled(isImporting)
-                importStatusLine
+                Picker("Active model", selection: $settings.selectedAPIModelID) {
+                    ForEach(settings.apiModels) { model in
+                        Text(model.displayName).tag(Optional(model.id))
+                    }
+                }
+                .onChange(of: settings.selectedAPIModelID) { reloadModel() }
             } header: {
-                Text("Use your own base model")
-            } footer: {
-                Text("KeyType is tuned for the models above; other models may produce unexpected or low-quality completions.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
+                Text("Selection")
+            }
+
+            Section {
+                Button("Add API Model…") { presentAddSheet() }
             }
         }
-        .formStyle(.grouped)
-        .task { availableModels = Self.loadModels() }
-        // A download/profile finishing changes a model's setup state but not `availableModels`,
-        // which is loaded from disk. Reading every model's state here establishes the observation
-        // dependency, so this fires (and re-reads the installed GGUFs) the moment one lands —
-        // making freshly downloaded models selectable without a restart.
-        .onChange(of: modelSetupSignature) { availableModels = Self.loadModels() }
-        // An import lands a brand-new file in the Models directory that isn't in the catalog, so it
-        // won't move `modelSetupSignature`. Re-read the installed GGUFs when the import state settles
-        // so the freshly imported model appears in (and can be shown selected by) the picker.
-        .onChange(of: modelSetup.importState) { availableModels = Self.loadModels() }
     }
 
-    /// Changes whenever any catalog model's combined setup state changes, so the picker stays in sync.
+    // MARK: - Add API model sheet
+
+    private var addAPIModelSheet: some View {
+        VStack(spacing: 0) {
+            Form {
+                Section("Add API Model") {
+                    TextField("Display name", text: $editDisplayName)
+                        .textFieldStyle(.roundedBorder)
+                    TextField("API endpoint", text: $editEndpoint)
+                        .textFieldStyle(.roundedBorder)
+                        .help("e.g. http://localhost:1234/v1")
+                    TextField("Model name", text: $editModelName)
+                        .textFieldStyle(.roundedBorder)
+                        .help("e.g. qwen2.5-7b-instruct, gpt-4o-mini")
+                    SecureField("API key (optional)", text: $editAPIKey)
+                        .textFieldStyle(.roundedBorder)
+                }
+            }
+            .formStyle(.grouped)
+
+            HStack {
+                Button("Cancel", role: .cancel) {
+                    showAddAPIModel = false
+                }
+                Spacer()
+                Button("Add") {
+                    let config = APIModelConfig(
+                        displayName: editDisplayName,
+                        endpoint: editEndpoint,
+                        apiKey: editAPIKey,
+                        modelName: editModelName
+                    )
+                    settings.apiModels.append(config)
+                    settings.selectedAPIModelID = config.id
+                    resetEditFields()
+                    showAddAPIModel = false
+                    reloadModel()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(editDisplayName.isEmpty || editEndpoint.isEmpty || editModelName.isEmpty)
+            }
+            .padding()
+        }
+        .frame(width: 480)
+    }
+
+    private func presentAddSheet() {
+        resetEditFields()
+        showAddAPIModel = true
+    }
+
+    private func resetEditFields() {
+        editDisplayName = ""
+        editEndpoint = ""
+        editAPIKey = ""
+        editModelName = ""
+    }
+
+    // MARK: - Shared helpers
+
     private var modelSetupSignature: String {
         modelSetup.catalog
             .map { "\($0.filename):\(String(describing: modelSetup.state(for: $0)))" }


### PR DESCRIPTION
## Summary

Adds an OpenAI-compatible API provider as an alternative to running local GGUF models. Users can now offload inference to LM Studio, Ollama, vLLM, or any OpenAI-compatible endpoint — saving Mac GPU/RAM resources.

Closes #18

## Changes

- **CompletionEngine protocol** — abstracts over local and remote inference engines
- **OpenAICompletionEngine** — sends prompts to OpenAI-compatible chat APIs via URLSession
- **APIModelConfig model** — endpoint URL, API key, model name per configured provider
- **SettingsStore** —  toggle,  list, 
- **ModelSettingsView** — Engine picker (Local/Remote), API model add/delete/selection
- **CompletionController** — routes to local or remote engine builder based on setting

## Usage

1. Settings → Model → Engine → **Remote API**
2. Click **Add API Model**
3. Enter display name, endpoint URL, model name, optional API key
4. Select the active model from the list
5. The engine reloads immediately

## Architecture

The  protocol mirrors what  already calls:
```
protocol CompletionEngine {
    func completions(for: CompletionRequest) async throws -> [CompletionCandidate]
    func warmUp(for: CompletionRequest) async throws
    func shutdown() async
}
```

Both `ConstrainedGenerationEngine` (local) and `OpenAICompletionEngine` (remote) conform, so switching between them requires no pipeline changes.