### PR TITLE
fix: resolve bare detected-language tags to the user's regional spelling dictionary

### DIFF
--- a/KeyType.xcodeproj/project.pbxproj
+++ b/KeyType.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		4B5450012FC9600000000043 /* CompletionAcceptanceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5450012FC9600000000042 /* CompletionAcceptanceController.swift */; };
 		4B5450012FC9600000000045 /* FieldFontResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5450012FC9600000000044 /* FieldFontResolver.swift */; };
 		4B5450012FC9600000000047 /* SystemWordRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5450012FC9600000000046 /* SystemWordRecognizer.swift */; };
+		4B5450012FC9600000000902 /* SpellingLanguage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5450012FC9600000000901 /* SpellingLanguage.swift */; };
 		4B5450012FC9600000000501 /* CorrectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5450012FC9600000000500 /* CorrectionController.swift */; };
 		4B5450012FC9600000000503 /* SystemSpellcheckCorrectionDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5450012FC9600000000502 /* SystemSpellcheckCorrectionDetector.swift */; };
 		4B5450012FC9600000000051 /* LlamaModelRuntime in Frameworks */ = {isa = PBXBuildFile; productRef = 4B5450012FC9600000000050 /* LlamaModelRuntime */; };
@@ -109,6 +110,7 @@
 		4B5450012FC9600000000042 /* CompletionAcceptanceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionAcceptanceController.swift; sourceTree = "<group>"; };
 		4B5450012FC9600000000044 /* FieldFontResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FieldFontResolver.swift; sourceTree = "<group>"; };
 		4B5450012FC9600000000046 /* SystemWordRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemWordRecognizer.swift; sourceTree = "<group>"; };
+		4B5450012FC9600000000901 /* SpellingLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpellingLanguage.swift; sourceTree = "<group>"; };
 		4B5450012FC9600000000500 /* CorrectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CorrectionController.swift; sourceTree = "<group>"; };
 		4B5450012FC9600000000502 /* SystemSpellcheckCorrectionDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemSpellcheckCorrectionDetector.swift; sourceTree = "<group>"; };
 		4B5450012FC9600000000049 /* KeyType.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = KeyType.entitlements; sourceTree = "<group>"; };
@@ -307,6 +309,7 @@
 				4B5450012FC96000000002A2 /* CompletionReuseHistory.swift */,
 				4B5450012FC9600000000044 /* FieldFontResolver.swift */,
 				4B5450012FC9600000000046 /* SystemWordRecognizer.swift */,
+				4B5450012FC9600000000901 /* SpellingLanguage.swift */,
 			);
 			path = Completion;
 			sourceTree = "<group>";
@@ -653,6 +656,7 @@
 				4B5450012FC9600000000043 /* CompletionAcceptanceController.swift in Sources */,
 				4B5450012FC9600000000045 /* FieldFontResolver.swift in Sources */,
 				4B5450012FC9600000000047 /* SystemWordRecognizer.swift in Sources */,
+				4B5450012FC9600000000902 /* SpellingLanguage.swift in Sources */,
 				4B5450012FC9600000000501 /* CorrectionController.swift in Sources */,
 				4B5450012FC9600000000503 /* SystemSpellcheckCorrectionDetector.swift in Sources */,
 				4B5450012FC9600000000311 /* FullPromptLog.swift in Sources */,

--- a/KeyType/Logic/Completion/SpellingLanguage.swift
+++ b/KeyType/Logic/Completion/SpellingLanguage.swift
@@ -1,0 +1,43 @@
+//
+//  SpellingLanguage.swift
+//  KeyType
+//
+//  Shared detected-language → installed-dictionary resolution for every `NSSpellChecker`
+//  consumer (typo guard, dead-end guard, output filter, correction lane). See ADR-116.
+//
+
+import Foundation
+
+/// Maps a detected-language tag onto an installed spelling dictionary.
+///
+/// `LanguageDetector` emits *base* tags only (`"en"`, never `"en-GB"`), and macOS's generic `"en"`
+/// dictionary is US-flavoured — it flags `colour`/`realise` as misspellings. So a bare base tag is
+/// first refined with the user's preferred regional variant of that language
+/// (`Locale.preferredLanguages`, the same OS-derived signal ADR-089 uses for prompt style) before
+/// falling back to the generic dictionary. A region-qualified request keeps exact-match priority;
+/// unknown languages fall back to their base and then to `nil` (checker auto-detect), so we never
+/// force the checker into a language it can't handle.
+enum SpellingLanguage {
+    static func resolve(
+        _ requested: String?,
+        availableLanguages: [String],
+        preferredLanguages: [String] = Locale.preferredLanguages
+    ) -> String? {
+        guard let requested, !requested.isEmpty else { return nil }
+        let normalized = requested.replacingOccurrences(of: "-", with: "_")
+        let base = String(normalized.prefix { $0 != "_" })
+        // Bare base tag → prefer the user's own regional variant of that language (e.g. detected
+        // "en" on an en-GB system resolves to "en_GB", not the US-flavoured "en").
+        if normalized == base {
+            for preferred in preferredLanguages {
+                let variant = preferred.replacingOccurrences(of: "-", with: "_")
+                if variant.hasPrefix("\(base)_"), availableLanguages.contains(variant) {
+                    return variant
+                }
+            }
+        }
+        if availableLanguages.contains(normalized) { return normalized }
+        if availableLanguages.contains(base) { return base }
+        return nil
+    }
+}

--- a/KeyType/Logic/Completion/SpellingLanguage.swift
+++ b/KeyType/Logic/Completion/SpellingLanguage.swift
@@ -3,7 +3,7 @@
 //  KeyType
 //
 //  Shared detected-language → installed-dictionary resolution for every `NSSpellChecker`
-//  consumer (typo guard, dead-end guard, output filter, correction lane). See ADR-116.
+//  consumer (typo guard, dead-end guard, output filter, correction lane). See ADR-122.
 //
 
 import Foundation
@@ -12,7 +12,7 @@ import Foundation
 ///
 /// `LanguageDetector` emits *base* tags only (`"en"`, never `"en-GB"`), and macOS's generic `"en"`
 /// dictionary is US-flavoured — it flags `colour`/`realise` as misspellings. So a bare base tag is
-/// first refined with the user's preferred regional variant of that language
+/// first refined with the user's highest-priority preferred variant of that language
 /// (`Locale.preferredLanguages`, the same OS-derived signal ADR-089 uses for prompt style) before
 /// falling back to the generic dictionary. A region-qualified request keeps exact-match priority;
 /// unknown languages fall back to their base and then to `nil` (checker auto-detect), so we never
@@ -27,13 +27,19 @@ enum SpellingLanguage {
         let normalized = requested.replacingOccurrences(of: "-", with: "_")
         let base = String(normalized.prefix { $0 != "_" })
         // Bare base tag → prefer the user's own regional variant of that language (e.g. detected
-        // "en" on an en-GB system resolves to "en_GB", not the US-flavoured "en").
+        // "en" on an en-GB system resolves to "en_GB", not the US-flavoured "en"). Consider only
+        // the highest-priority matching preference: if en-US is primary but en_US is not installed,
+        // falling through to a secondary en-CA preference would silently select the wrong dialect.
         if normalized == base {
-            for preferred in preferredLanguages {
-                let variant = preferred.replacingOccurrences(of: "-", with: "_")
-                if variant.hasPrefix("\(base)_"), availableLanguages.contains(variant) {
-                    return variant
+            let preferred = preferredLanguages
+                .map { $0.replacingOccurrences(of: "-", with: "_") }
+                .first { preference in
+                    String(preference.prefix { $0 != "_" }) == base
                 }
+            if let preferred,
+               preferred != base,
+               availableLanguages.contains(preferred) {
+                return preferred
             }
         }
         if availableLanguages.contains(normalized) { return normalized }

--- a/KeyType/Logic/Completion/SystemWordRecognizer.swift
+++ b/KeyType/Logic/Completion/SystemWordRecognizer.swift
@@ -76,16 +76,10 @@ struct SystemWordRecognizer: WordRecognizing, SynchronousWordRecognizing {
         return misspelled.location == NSNotFound
     }
 
-    /// Map a detected-language tag (BCP-47 `"en-US"` or NSSpellChecker `"en_US"`) onto an installed
-    /// dictionary, falling back to the base language and then to `nil` (auto-detect) so we never
-    /// force a checker into a language it can't handle.
+    /// Map a detected-language tag onto an installed dictionary via `SpellingLanguage` (ADR-116):
+    /// a bare base tag ("en") is refined with the user's preferred regional variant ("en_GB")
+    /// before the generic dictionary, then falls back to base and `nil` (auto-detect).
     private static func resolveLanguage(_ requested: String?, checker: NSSpellChecker) -> String? {
-        guard let requested, !requested.isEmpty else { return nil }
-        let normalized = requested.replacingOccurrences(of: "-", with: "_")
-        let available = checker.availableLanguages
-        if available.contains(normalized) { return normalized }
-        let base = String(normalized.prefix { $0 != "_" })
-        if available.contains(base) { return base }
-        return nil
+        SpellingLanguage.resolve(requested, availableLanguages: checker.availableLanguages)
     }
 }

--- a/KeyType/Logic/Completion/SystemWordRecognizer.swift
+++ b/KeyType/Logic/Completion/SystemWordRecognizer.swift
@@ -76,7 +76,7 @@ struct SystemWordRecognizer: WordRecognizing, SynchronousWordRecognizing {
         return misspelled.location == NSNotFound
     }
 
-    /// Map a detected-language tag onto an installed dictionary via `SpellingLanguage` (ADR-116):
+    /// Map a detected-language tag onto an installed dictionary via `SpellingLanguage` (ADR-122):
     /// a bare base tag ("en") is refined with the user's preferred regional variant ("en_GB")
     /// before the generic dictionary, then falls back to base and `nil` (auto-detect).
     private static func resolveLanguage(_ requested: String?, checker: NSSpellChecker) -> String? {

--- a/KeyType/Logic/Correction/SystemSpellcheckCorrectionDetector.swift
+++ b/KeyType/Logic/Correction/SystemSpellcheckCorrectionDetector.swift
@@ -337,13 +337,9 @@ struct SystemGrammarCorrectionDetector {
 }
 
 private enum SystemCorrectionLanguage {
+    /// Resolution shared with the completion path (`SpellingLanguage`, ADR-116) so the correction
+    /// lane can never "correct" a regional spelling the typo guard accepts (colour → color).
     static func resolve(_ requested: String?, checker: NSSpellChecker) -> String? {
-        guard let requested, !requested.isEmpty else { return nil }
-        let normalized = requested.replacingOccurrences(of: "-", with: "_")
-        let available = checker.availableLanguages
-        if available.contains(normalized) { return normalized }
-        let base = String(normalized.prefix { $0 != "_" })
-        if available.contains(base) { return base }
-        return nil
+        SpellingLanguage.resolve(requested, availableLanguages: checker.availableLanguages)
     }
 }

--- a/KeyType/Logic/Correction/SystemSpellcheckCorrectionDetector.swift
+++ b/KeyType/Logic/Correction/SystemSpellcheckCorrectionDetector.swift
@@ -337,7 +337,7 @@ struct SystemGrammarCorrectionDetector {
 }
 
 private enum SystemCorrectionLanguage {
-    /// Resolution shared with the completion path (`SpellingLanguage`, ADR-116) so the correction
+    /// Resolution shared with the completion path (`SpellingLanguage`, ADR-122) so the correction
     /// lane can never "correct" a regional spelling the typo guard accepts (colour → color).
     static func resolve(_ requested: String?, checker: NSSpellChecker) -> String? {
         SpellingLanguage.resolve(requested, availableLanguages: checker.availableLanguages)

--- a/KeyTypeTests/KeyTypeTests.swift
+++ b/KeyTypeTests/KeyTypeTests.swift
@@ -162,6 +162,40 @@ struct KeyTypeTests {
         ) == 4)
     }
 
+    @Test func spellingLanguageRefinesBareTagWithPreferredInstalledVariant() {
+        #expect(SpellingLanguage.resolve(
+            "en",
+            availableLanguages: ["en", "en_AU", "en_GB"],
+            preferredLanguages: ["fr-FR", "en-GB", "en-AU"]
+        ) == "en_GB")
+    }
+
+    @Test func spellingLanguageKeepsExplicitRegionalRequest() {
+        #expect(SpellingLanguage.resolve(
+            "en-GB",
+            availableLanguages: ["en", "en_GB"],
+            preferredLanguages: ["en-AU"]
+        ) == "en_GB")
+    }
+
+    @Test func spellingLanguageFallsBackConservatively() {
+        #expect(SpellingLanguage.resolve(
+            "en",
+            availableLanguages: ["en", "en_CA"],
+            preferredLanguages: ["en-US", "en-CA"]
+        ) == "en")
+        #expect(SpellingLanguage.resolve(
+            "fr",
+            availableLanguages: ["en"],
+            preferredLanguages: ["fr-CA"]
+        ) == nil)
+        #expect(SpellingLanguage.resolve(
+            nil,
+            availableLanguages: ["en_GB"],
+            preferredLanguages: ["en-GB"]
+        ) == nil)
+    }
+
     @Test @MainActor func correctionSuffixWindowIgnoresLeadingPunctuation() {
         #expect(CompletionController.correctionSuffixWindow(from: " , they are shown") == "")
         #expect(CompletionController.correctionSuffixWindow(from: ", they are shown") == "")

--- a/docs/05-decisions.md
+++ b/docs/05-decisions.md
@@ -141,6 +141,7 @@ row here.**
 | 119 | Promote generated beam state into typed anchors | model-runtime/performance |
 | 120 | Adapt beam work to visible-candidate certainty | generation/performance |
 | 121 | Batch correction candidates by token depth | generation/performance |
+| 122 | Refine bare detected-language tags with the user's regional variant | generation/correction |
 
 ---
 
@@ -3701,3 +3702,27 @@ text. Both are now closed:
   from 18 serial paths to 8 batched frontiers and wall time from 103.1 ms to 62.9 ms (39%), while
   returning the same validated replacements. Empty or unscorable paths still receive negative
   infinity and are suppressed by the existing thresholds.
+## ADR-122 — Refine bare detected-language tags with the user's regional variant
+
+- Date: 2026-07-10
+- Status: accepted
+- Context: `LanguageDetector` (NLLanguageRecognizer) emits base tags only (`"en"`, never
+  `"en-GB"`), and both spell-language resolvers (`SystemWordRecognizer.resolveLanguage`, the
+  correction lane's `SystemCorrectionLanguage.resolve`) exact-matched that bare tag against
+  `NSSpellChecker.availableLanguages` — resolving to the generic `"en"` dictionary, which is
+  US-flavoured (empirically: `colour`/`realise`/`organise` flagged as misspellings;
+  `completions(forPartialWordRange:)` on `"colou"` returns 0). On a British-English system this
+  made the in-beam typo guard (ADR-015) drop correctly-spelled British branches, the dead-end
+  guard (ADR-052/056) suppress completions mid-word (`currentWordHasNoValidCompletion`), and the
+  correction lane liable to "correct" British spellings toward US.
+- Decision: Add a shared app-target resolver (`SpellingLanguage.resolve`): when the requested tag
+  is a bare base tag, first look for the user's preferred regional variant of that language
+  (`Locale.preferredLanguages` — the same OS-derived signal ADR-089 uses for prompt style) among
+  the installed dictionaries; only then fall back to exact match, base, and `nil` (auto-detect).
+  Region-qualified requests keep exact-match priority; both existing resolvers delegate to it.
+- Consequences: On an `en-GB` system, detected `"en"` now resolves to `en_GB` (verified by a
+  compiled harness against the live checker: British words recognised, `color`/`realize` flagged,
+  `"colou"` yields 20 completions). US-preference systems are unchanged (`en_US` is not an
+  installed dictionary; resolution falls back to `"en"` as before). Non-English languages with
+  regional prefs (e.g. `fr-CA`) gain the same refinement. The resolver is a pure function covered
+  by deterministic app-target tests.

--- a/docs/05-decisions.md
+++ b/docs/05-decisions.md
@@ -3702,9 +3702,10 @@ text. Both are now closed:
   from 18 serial paths to 8 batched frontiers and wall time from 103.1 ms to 62.9 ms (39%), while
   returning the same validated replacements. Empty or unscorable paths still receive negative
   infinity and are suppressed by the existing thresholds.
+
 ## ADR-122 — Refine bare detected-language tags with the user's regional variant
 
-- Date: 2026-07-10
+- Date: 2026-08-29
 - Status: accepted
 - Context: `LanguageDetector` (NLLanguageRecognizer) emits base tags only (`"en"`, never
   `"en-GB"`), and both spell-language resolvers (`SystemWordRecognizer.resolveLanguage`, the
@@ -3716,9 +3717,10 @@ text. Both are now closed:
   guard (ADR-052/056) suppress completions mid-word (`currentWordHasNoValidCompletion`), and the
   correction lane liable to "correct" British spellings toward US.
 - Decision: Add a shared app-target resolver (`SpellingLanguage.resolve`): when the requested tag
-  is a bare base tag, first look for the user's preferred regional variant of that language
+  is a bare base tag, first look at the user's highest-priority preferred variant of that language
   (`Locale.preferredLanguages` — the same OS-derived signal ADR-089 uses for prompt style) among
-  the installed dictionaries; only then fall back to exact match, base, and `nil` (auto-detect).
+  the installed dictionaries. If that primary variant is unavailable, fall back to exact match,
+  base, and `nil` (auto-detect), rather than selecting a lower-priority regional preference.
   Region-qualified requests keep exact-match priority; both existing resolvers delegate to it.
 - Consequences: On an `en-GB` system, detected `"en"` now resolves to `en_GB` (verified by a
   compiled harness against the live checker: British words recognised, `color`/`realize` flagged,


### PR DESCRIPTION
`NLLanguageRecognizer` emits base tags only (`"en"`, never `"en-GB"`), and both spell-language resolvers exact-match that against `NSSpellChecker.availableLanguages` — landing on the generic `"en"` dictionary, which is US-flavoured. On a British-English system this makes the in-beam typo guard drop correctly-spelled branches (*colour*, *realise*), the dead-end guard suppress completions mid-word (`completions("en", "colou")` returns 0), and the correction lane liable to "fix" British spellings toward US.

This PR adds a shared resolver (`SpellingLanguage.resolve`): a bare base tag is first refined with the user's preferred regional variant of that language (`Locale.preferredLanguages` — the same OS-derived signal ADR-089 uses for prompt style) before falling back to exact match, base, and `nil`. US-preference systems are unchanged (`en_US` isn't an installed dictionary; resolution falls back to `"en"` as before); other languages with regional preferences (e.g. `fr-CA`) gain the same refinement. Verified against the live checker: `en`→`en_GB` on an en-GB system, British words recognised, `color`/`realize` still flagged.

Corresponds to ADR-116 in my fork's decision log; happy to adjust numbering/format to your conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)